### PR TITLE
Test correction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PULUMI_BACKEND_URL=file://
 ENDPOINT=http://localhost:4566
 AWS_ACCESS_KEY=test
 AWS_SECRET_ACCESS_KEY=test
+LOCALSTACK_HOSTNAME=localhost.localstack.cloud
 
 .PHONY: all cleanup get-logs-aws run-test
 
@@ -26,6 +27,7 @@ get-logs-aws:
 	docker logs localstack -f
 # run the test -> will come back as pass since we dont check for return but print from within lambda should show up in logs
 run-test:
+	export LOCALSTACK_HOSTNAME=$(LOCALSTACK_HOSTNAME); \
 	source ./venv/bin/activate; \
 	cd tests; \
 	pytest -s;
@@ -52,7 +54,8 @@ get-logs-s3-on-object-created:
 # Raw recipes
 # ==============================
 up:
-	docker-compose up -d
+	export LOCALSTACK_HOSTNAME=$(LOCALSTACK_HOSTNAME); \
+	docker-compose up -d;
 
 install-iac-deps:
 	cd ./iac/ && yarn install;

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ AWS_SECRET_ACCESS_KEY=test
 # ==============================
 
 # build everything && install dependencies
-all: up install-iac-deps install-test-deps build-pulumi run-test
+all: install-iac-deps install-test-deps build-pulumi run-test
 # tears down everything
 cleanup: down reset-iac remove-test-deps
 # get the localstack logs
@@ -28,7 +28,7 @@ get-logs-aws:
 run-test:
 	source ./venv/bin/activate; \
 	cd tests; \
-	pytest;
+	pytest -s;
 
 # =======
 # localstack aws profile

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ AWS_SECRET_ACCESS_KEY=test
 # ==============================
 
 # build everything && install dependencies
-all: install-iac-deps install-test-deps build-pulumi run-test
+all: up install-iac-deps install-test-deps build-pulumi run-test
 # tears down everything
 cleanup: down reset-iac remove-test-deps
 # get the localstack logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
       - DEFAULT_REGION=us-west-2
+      - LOCALSTACK_HOSTNAME=${LOCALSTACK_HOSTNAME}
       - LAMBDA_DOCKER_NETWORK=devnet
       - HOSTNAME_EXTERNAL=host.docker.internal
       - LAMBDA_EXECUTOR=docker-reuse

--- a/s3_on_object_created_processing/lambda_function.py
+++ b/s3_on_object_created_processing/lambda_function.py
@@ -3,9 +3,12 @@ import urllib.parse
 
 # if invoked with onObjectCreated then should output logs
 def lambda_handler(event, context):
+    objects = []
     for record in event["Records"]:
         bucket = record["s3"]["bucket"]["name"]
         key = urllib.parse.unquote_plus(record["s3"]["object"]["key"], encoding="utf-8")
 
         print("bucket - " + bucket + "\n")
         print("key - " + key + "\n")
+        objects.append(f"{bucket}/{key}")
+    return objects

--- a/tests/onObjectCreate_test.py
+++ b/tests/onObjectCreate_test.py
@@ -17,8 +17,10 @@ def change_host_of_url_to_localhost(url: str):
     # TODO prepend bucket to end doesn't work
     # url = "http://" + os.environ["LOCALSTACK_HOSTNAME"] + ":4566" + url.split(":4566")[1]
     # TODO add bucket in url like in PR logs doesn't work
+    print(f"original url: {url}")
     url = "http://" + url.split(":4566/")[1] + "." + os.environ["LOCALSTACK_HOSTNAME"] + ":4566"
-    print(url)
+    # url = "http://" + url.split("://")[-1].split(".")[0] + ".localhost.localstack.cloud:4566"
+    print(f"altered url: {url}")
     return url
 
 

--- a/tests/onObjectCreate_test.py
+++ b/tests/onObjectCreate_test.py
@@ -1,3 +1,4 @@
+import os
 import json
 import requests
 
@@ -12,8 +13,11 @@ def presigned_url_lambda_apigw_url() -> str:
     return "http://" + api_id + the_sauce + api_stage + "/get_presigned_url"
 
 
-def change_host_of_url_to_localhost(url: str, remove_protocol: bool = True):
-    url = "http://" + url.split("://")[-1].split(".")[0] + ".localhost.localstack.cloud:4566"
+def change_host_of_url_to_localhost(url: str):
+    # TODO prepend bucket to end doesn't work
+    # url = "http://" + os.environ["LOCALSTACK_HOSTNAME"] + ":4566" + url.split(":4566")[1]
+    # TODO add bucket in url like in PR logs doesn't work
+    url = "http://" + url.split(":4566/")[1] + "." + os.environ["LOCALSTACK_HOSTNAME"] + ":4566"
     print(url)
     return url
 

--- a/tests/onObjectCreate_test.py
+++ b/tests/onObjectCreate_test.py
@@ -13,7 +13,9 @@ def presigned_url_lambda_apigw_url() -> str:
 
 
 def change_host_of_url_to_localhost(url: str, remove_protocol: bool = True):
-    return "http://localhost:" + url.split("://")[-1].split(":")[-1]
+    url = "http://" + url.split("://")[-1].split(".")[0] + ".localhost.localstack.cloud:4566"
+    print(url)
+    return url
 
 
 def format_res(resp) -> dict:
@@ -48,14 +50,10 @@ def test_error_no_files():
     post_url = res["content"]["data"]["url"]
     post_fields = res["content"]["data"]["fields"]
     # add file as last in post fields
-    post_fields["file"] = open(f"../{query_string['file_name']}", "rb")
-
-    headers = {
-        "Content-Type": "multipart/form-data; boundary=----"
-    }
+    files = {"file" : open(f"../{query_string['file_name']}", "rb")}
 
     # make post request to presigned url | should trigger lambda & display logs
-    res2 = format_res(requests.post(change_host_of_url_to_localhost(post_url), data=post_fields, headers=headers))
+    res2 = format_res(requests.post(change_host_of_url_to_localhost(post_url), data=post_fields, files=files))
     print(res2)
     # TODO doesn't show in localstack logs nor lambda specific logs | no lambda log output
     # run from root -- make get-logs-s3-on-object-created -- to see lambda specific logs
@@ -85,7 +83,3 @@ def test_error_with_files():
     # make post request to presigned url | should trigger lambda & display logs
     res2 = format_res(requests.post(change_host_of_url_to_localhost(post_url), data=post_fields, files=files))
     print(res2)
-    # TODO can see lambda fire in localstack logs, nothing shows in lambda specific logs. Lambda log output never shows
-    # see screenshot in logs dir (../logs) where we can see lambda does fire but no logs
-    # run from root -- make get-logs-s3-on-object-created -- to see lambda specific logs
-    # run from root -- make get-logs-aws -- to see localstack logs


### PR DESCRIPTION
Hi @kingster307 I made some small changes to your tests so they are successful with Localstack. 
![Screenshot from 2022-07-25 10-14-51](https://user-images.githubusercontent.com/18080804/180813492-ecd4bc8c-d398-41ba-ae2d-fff1f1731e3b.png)


```logs
>START RequestId: e0874d3b-3e96-19b0-e68a-a934033b6387 Version: $LATEST
> bucket - proj-bucket-prefix-20220725144527854900000001
> 
> key - presigned_url_prefix/cd57d1ae-735d-445b-81f1-0e5f95b38298
> 
> END RequestId: e0874d3b-3e96-19b0-e68a-a934033b6387
> REPORT RequestId: e0874d3b-3e96-19b0-e68a-a934033b6387        Init Duration: 151.49 ms        Duration: 2.25 ms       Billed Duration: 3 ms Memory Size: 1536 MB     Max Memory Used: 18 MB
2022-07-25T09:55:57.010 DEBUG --- [   asgi_gw_2] l.s.a.lambda_executors     : Lambda arn:aws:lambda:us-west-2:000000000000:function:s3CreatePresignedUrlLambda-3f10217 result / log output:
{"statusCode":200,"headers":{"Access-Control-Allow-Origin":"*","Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token"},"body":"{\"status\": true, \"message\": null, \"data\": {\"url\": \"https://proj-bucket-prefix-20220725144527854900000001.s3.amazonaws.com/\", \"fields\": {\"content-type\": \"csv\", \"x-amz-meta-action\": \"upload\", \"x-amz-meta-filename\": \"demo_file.csv\", \"key\": \"presigned_url_prefix/d9d8fe39-49ca-4a5e-9d18-a579fa75277c\", \"AWSAccessKeyId\": \"test\", \"policy\": \"eyJleHBpcmF0aW9uIjogIjIwMjItMDctMjVUMTU6NTU6NTZaIiwgImNvbmRpdGlvbnMiOiBbWyJlcSIsICIka2V5IiwgInByZXNpZ25lZF91cmxfcHJlZml4L2Q5ZDhmZTM5LTQ5Y2EtNGE1ZS05ZDE4LWE1NzlmYTc1Mjc3YyJdLCBbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwgMSwgMTAwMDAwMDAwMF0sIFsiZXEiLCAiJGNvbnRlbnQtdHlwZSIsICJjc3YiXSwgWyJlcSIsICIkeC1hbXotbWV0YS1hY3Rpb24iLCAidXBsb2FkIl0sIFsiZXEiLCAiJHgtYW16LW1ldGEtZmlsZW5hbWUiLCAiZGVtb19maWxlLmNzdiJdLCB7ImJ1Y2tldCI6ICJwcm9qLWJ1Y2tldC1wcmVmaXgtMjAyMjA3MjUxNDQ1Mjc4NTQ5MDAwMDAwMDEifSwgeyJrZXkiOiAicHJlc2lnbmVkX3VybF9wcmVmaXgvZDlkOGZlMzktNDljYS00YTVlLTlkMTgtYTU3OWZhNzUyNzdjIn1dfQ==\", \"signature\": \"hRCMhK31rY3iwB3+s52kG6OWR7g=\"}}}"}
>START RequestId: bb0d4de1-e3dd-172e-6db3-af706aaf9294 Version: $LATEST
> {'path': '/get_presigned_url', 'headers': {'Host': '5ug9edtdvf.execute-api.localhost.localstack.cloud:4566', 'User-Agent': 'python-requests/2.27.1', 'accept-encoding': 'gzip, deflate', 'accept': '*/*', 'Connection': 'keep-alive', 'x-localstack-tgt-api': 'apigateway', 'X-Forwarded-For': '127.0.0.1, 5ug9edtdvf.execute-api.localhost.localstack.cloud:4566', 'x-localstack-edge': 'http://5ug9edtdvf.execute-api.localhost.localstack.cloud:4566', 'Authorization': ''}, 'multiValueHeaders': {'Host': ['5ug9edtdvf.execute-api.localhost.localstack.cloud:4566'], 'User-Agent': ['python-requests/2.27.1'], 'accept-encoding': ['gzip, deflate'], 'accept': ['*/*'], 'Connection': ['keep-alive'], 'x-localstack-tgt-api': ['apigateway'], 'X-Forwarded-For': ['127.0.0.1, 5ug9edtdvf.execute-api.localhost.localstack.cloud:4566'], 'x-localstack-edge': ['http://5ug9edtdvf.execute-api.localhost.localstack.cloud:4566'], 'Authorization': ['']}, 'body': '', 'isBase64Encoded': False, 'httpMethod': 'GET', 'queryStringParameters': {'action': 'upload', 'file_name': 'demo_file.csv', 'content_type': 'csv'}, 'multiValueQueryStringParameters': {'action': ['upload'], 'file_name': ['demo_file.csv'], 'content_type': ['csv']}, 'pathParameters': {}, 'resource': '/get_presigned_url', 'requestContext': {'accountId': '000000000000', 'apiId': '5ug9edtdvf', 'resourcePath': '/get_presigned_url', 'domainPrefix': '5ug9edtdvf', 'domainName': '5ug9edtdvf.execute-api.localhost.localstack.cloud', 'resourceId': 'dv7378074i', 'requestId': '320d7ed0-3091-415c-8d05-a70359b0b8bf', 'identity': {'accountId': '000000000000', 'sourceIp': '127.0.0.1', 'userAgent': 'python-requests/2.27.1'}, 'httpMethod': 'GET', 'protocol': 'HTTP/1.1', 'requestTime': '25/Jul/2022:14:55:56 +0000', 'requestTimeEpoch': 1658760956206, 'authorizer': {'context': {}, 'identity': {}}, 'path': '/api/get_presigned_url', 'stage': 'api'}, 'stageVariables': {}}
> END RequestId: b...
2022-07-25T09:55:57.124  INFO --- [   asgi_gw_2] localstack.request.http    : GET /api/get_presigned_url => 200
2022-07-25T09:55:57.225 DEBUG --- [uest_thread)] l.s.a.lambda_executors     : Lambda executed in Event (asynchronous) mode, no response will be returned to caller
2022-07-25T09:55:57.228  INFO --- [  Thread-272] l.s.a.lambda_executors     : Running lambda: arn:aws:lambda:us-west-2:000000000000:function:s3OnObjectCreatedLambda-8491fcc
2022-07-25T09:55:57.229 DEBUG --- [  Thread-272] l.u.c.docker_cmd_client    : Create container with cmd: ['docker', 'create', '--rm', '-v', '/home/cristopher/Projects/localstack/.filesystem/var/lib/localstack/tmp/zipfile.81a0f4b9:/var/task', '--interactive', '-e', 'AWS_ACCESS_KEY_ID=test', '-e', 'AWS_SECRET_ACCESS_KEY=test', '-e', 'AWS_REGION=us-west-2', '-e', 'DOCKER_LAMBDA_USE_STDIN=1', '-e', 'LOCALSTACK_HOSTNAME=172.17.0.1', '-e', 'EDGE_PORT=4566', '-e', '_HANDLER=lambda_function.lambda_handler', '-e', 'AWS_LAMBDA_FUNCTION_TIMEOUT=900', '-e', 'AWS_LAMBDA_FUNCTION_NAME=s3OnObjectCreatedLambda-8491fcc', '-e', 'AWS_LAMBDA_FUNCTION_VERSION=$LATEST', '-e', 'AWS_LAMBDA_FUNCTION_INVOKED_ARN=arn:aws:lambda:us-west-2:000000000000:function:s3OnObjectCreatedLambda-8491fcc', '--network', 'bridge', 'lambci/lambda:python3.7', 'lambda_function.lambda_handler']
2022-07-25T09:55:57.230 DEBUG --- [  Thread-272] localstack.utils.run       : Executing command: ['docker', 'create', '--rm', '-v', '/home/cristopher/Projects/localstack/.filesystem/var/lib/localstack/tmp/zipfile.81a0f4b9:/var/task', '--interactive', '-e', 'AWS_ACCESS_KEY_ID=test', '-e', 'AWS_SECRET_ACCESS_KEY=test', '-e', 'AWS_REGION=us-west-2', '-e', 'DOCKER_LAMBDA_USE_STDIN=1', '-e', 'LOCALSTACK_HOSTNAME=172.17.0.1', '-e', 'EDGE_PORT=4566', '-e', '_HANDLER=lambda_function.lambda_handler', '-e', 'AWS_LAMBDA_FUNCTION_TIMEOUT=900', '-e', 'AWS_LAMBDA_FUNCTION_NAME=s3OnObjectCreatedLambda-8491fcc', '-e', 'AWS_LAMBDA_FUNCTION_VERSION=$LATEST', '-e', 'AWS_LAMBDA_FUNCTION_INVOKED_ARN=arn:aws:lambda:us-west-2:000000000000:function:s3OnObjectCreatedLambda-8491fcc', '--network', 'bridge', 'lambci/lambda:python3.7', 'lambda_function.lambda_handler']
2022-07-25T09:55:57.238  INFO --- [   asgi_gw_1] localstack.request.aws     : AWS s3.DeleteObjects => 204
2022-07-25T09:55:57.299 DEBUG --- [  Thread-272] l.u.c.docker_cmd_client    : Start container with cmd: ['docker', 'start', '--interactive', '--attach', 'ce18222e4f5ff0b6b95c5ca84e1e04f89f977017bbb00660c1a564d56604db42']
2022-07-25T09:55:57.299 DEBUG --- [  Thread-272] localstack.utils.run       : Executing command: ['docker', 'start', '--interactive', '--attach', 'ce18222e4f5ff0b6b95c5ca84e1e04f89f977017bbb00660c1a564d56604db42']
2022-07-25T09:55:57.890 DEBUG --- [  Thread-272] l.s.a.lambda_executors     : Lambda arn:aws:lambda:us-west-2:000000000000:function:s3OnObjectCreatedLambda-8491fcc result / log output:
null
>START RequestId: 0d649a4a-95d9-1095-d79d-41b25e05e5f1 Version: $LATEST
> bucket - proj-bucket-prefix-20220725144527854900000001
> 
> key - presigned_url_prefix/d9d8fe39-49ca-4a5e-9d18-a579fa75277c
```